### PR TITLE
Add support for layoutUrl deep-link

### DIFF
--- a/packages/studio-base/src/Workspace.stories.tsx
+++ b/packages/studio-base/src/Workspace.stories.tsx
@@ -8,6 +8,7 @@ import { fireEvent, screen } from "@storybook/testing-library";
 import MultiProvider from "@foxglove/studio-base/components/MultiProvider";
 import Panel from "@foxglove/studio-base/components/Panel";
 import PanelToolbar from "@foxglove/studio-base/components/PanelToolbar";
+import LayoutManagerContext from "@foxglove/studio-base/context/LayoutManagerContext";
 import LayoutStorageContext from "@foxglove/studio-base/context/LayoutStorageContext";
 import PanelCatalogContext, {
   PanelCatalog,
@@ -79,6 +80,14 @@ export const Basic: StoryObj = {
       <EventsProvider />,
       <PanelCatalogContext.Provider value={new MockPanelCatalog()} />,
       <MockCurrentLayoutProvider initialState={{ layout: "Fake" }} />,
+      <LayoutManagerContext.Provider
+        value={
+          new LayoutManager({
+            local: new MockLayoutStorage(LayoutManager.LOCAL_STORAGE_NAMESPACE, []),
+            remote: undefined,
+          })
+        }
+      />,
       /* eslint-enable react/jsx-key */
     ];
     return (

--- a/packages/studio-base/src/hooks/useInitialDeepLinkState.test.tsx
+++ b/packages/studio-base/src/hooks/useInitialDeepLinkState.test.tsx
@@ -3,17 +3,22 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { renderHook } from "@testing-library/react-hooks";
+import { renderHook, act } from "@testing-library/react-hooks";
+import { useSnackbar } from "notistack";
 import { PropsWithChildren } from "react";
 
 import MockMessagePipelineProvider from "@foxglove/studio-base/components/MessagePipeline/MockMessagePipelineProvider";
 import { useCurrentLayoutActions } from "@foxglove/studio-base/context/CurrentLayoutContext";
 import CurrentUserContext, { User } from "@foxglove/studio-base/context/CurrentUserContext";
+import { useLayoutManager } from "@foxglove/studio-base/context/LayoutManagerContext";
 import PlayerSelectionContext, {
   IDataSourceFactory,
   PlayerSelection,
 } from "@foxglove/studio-base/context/PlayerSelectionContext";
-import { useInitialDeepLinkState } from "@foxglove/studio-base/hooks/useInitialDeepLinkState";
+import {
+  useInitialDeepLinkState,
+  formatLayoutUrl,
+} from "@foxglove/studio-base/hooks/useInitialDeepLinkState";
 import { useSessionStorageValue } from "@foxglove/studio-base/hooks/useSessionStorageValue";
 import { Player } from "@foxglove/studio-base/players/types";
 import EventsProvider from "@foxglove/studio-base/providers/EventsProvider";
@@ -21,6 +26,16 @@ import { LaunchPreferenceValue } from "@foxglove/studio-base/types/LaunchPrefere
 
 jest.mock("@foxglove/studio-base/hooks/useSessionStorageValue");
 jest.mock("@foxglove/studio-base/context/CurrentLayoutContext");
+jest.mock("@foxglove/studio-base/context/LayoutManagerContext");
+jest.mock("notistack");
+
+global.fetch = jest.fn(
+  async () =>
+    await Promise.resolve({
+      json: async () => await Promise.resolve({ test: 100 }),
+      ok: true,
+    }),
+) as jest.Mock;
 
 type WrapperProps = {
   currentUser?: User;
@@ -63,6 +78,8 @@ function makeWrapper(initialProps: WrapperProps) {
 describe("Initial deep link state", () => {
   const selectSource = jest.fn();
   const setSelectedLayoutId = jest.fn();
+  const saveNewLayout = jest.fn();
+  const getLayouts = jest.fn();
   const emptyPlayerSelection = {
     selectSource,
     selectRecent: () => {},
@@ -74,8 +91,12 @@ describe("Initial deep link state", () => {
   beforeEach(() => {
     (useSessionStorageValue as jest.Mock).mockReturnValue([LaunchPreferenceValue.WEB, jest.fn()]);
     (useCurrentLayoutActions as jest.Mock).mockReturnValue({ setSelectedLayoutId });
+    (useLayoutManager as jest.Mock).mockReturnValue({ saveNewLayout, getLayouts });
+    (useSnackbar as jest.Mock).mockReturnValue({ enqueueSnackbar: jest.fn() });
     selectSource.mockClear();
     setSelectedLayoutId.mockClear();
+    saveNewLayout.mockReturnValue(Promise.resolve({ id: 1234 }));
+    getLayouts.mockReturnValue(Promise.resolve([]));
   });
 
   it("doesn't select a source without ds params", () => {
@@ -175,5 +196,46 @@ describe("Initial deep link state", () => {
     });
 
     expect(setSelectedLayoutId).toHaveBeenCalledWith("12345");
+  });
+
+  it("opens and saves a layout from url and opens it", async () => {
+    const { wrapper } = makeWrapper({ playerSelection: emptyPlayerSelection });
+    renderHook(
+      () =>
+        useInitialDeepLinkState([
+          "https://studio.foxglove.dev/?layoutUrl=http%3A%2F%2Flocalhost%2flayout.json",
+        ]),
+      {
+        wrapper,
+      },
+    );
+
+    // Required to wait for the async callback to have completed
+    await act(async () => {
+      await new Promise((resolve) => process.nextTick(resolve));
+    });
+
+    expect(fetch).toHaveBeenCalled();
+    expect(saveNewLayout).toHaveBeenCalledWith({
+      name: "layout",
+      data: { test: 100 },
+      permission: "CREATOR_WRITE",
+    });
+    expect(setSelectedLayoutId).toHaveBeenCalledWith(1234);
+
+    return;
+  });
+
+  it("formats layoutUrls into the correct style when naming layouts", () => {
+    const simpleUrl = new URL("http://localhost/layout.json");
+    expect(formatLayoutUrl(simpleUrl)).toBe("layout");
+
+    const urlWithFolder = new URL("http://localhost/layout/demo.json");
+    expect(formatLayoutUrl(urlWithFolder)).toBe("demo");
+
+    const s3PreSignedUrl = new URL(
+      "https://im-a-bucket.s3.amazonaws.com/folder/debug.json?AWSAccessKeyId=xxxxxx&Signature=xxxxxx&x-amz-security-token=xxxx&Expires=0",
+    );
+    expect(formatLayoutUrl(s3PreSignedUrl)).toBe("debug");
   });
 });

--- a/packages/studio-base/src/hooks/useInitialDeepLinkState.ts
+++ b/packages/studio-base/src/hooks/useInitialDeepLinkState.ts
@@ -2,7 +2,7 @@
 // License, v2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import Log from "@foxglove/log";
 import {
@@ -10,10 +10,14 @@ import {
   useMessagePipeline,
 } from "@foxglove/studio-base/components/MessagePipeline";
 import { useCurrentLayoutActions } from "@foxglove/studio-base/context/CurrentLayoutContext";
+import { LayoutData } from "@foxglove/studio-base/context/CurrentLayoutContext/actions";
 import { useCurrentUser } from "@foxglove/studio-base/context/CurrentUserContext";
 import { EventsStore, useEvents } from "@foxglove/studio-base/context/EventsContext";
+import { useLayoutManager } from "@foxglove/studio-base/context/LayoutManagerContext";
 import { usePlayerSelection } from "@foxglove/studio-base/context/PlayerSelectionContext";
+import useCallbackWithToast from "@foxglove/studio-base/hooks/useCallbackWithToast";
 import { PlayerPresence } from "@foxglove/studio-base/players/types";
+import { LayoutID } from "@foxglove/studio-base/services/ILayoutStorage";
 import { AppURLState, parseAppURLState } from "@foxglove/studio-base/util/appURLState";
 
 const selectPlayerPresence = (ctx: MessagePipelineContext) => ctx.playerState.presence;
@@ -21,6 +25,10 @@ const selectSeek = (ctx: MessagePipelineContext) => ctx.seekPlayback;
 const selectSelectEvent = (store: EventsStore) => store.selectEvent;
 
 const log = Log.getLogger(__filename);
+
+export function formatLayoutUrl(layoutUrl: URL): string {
+  return layoutUrl.pathname.replace(/.*\//, "").replace(".json", "");
+}
 
 /*
  * Separation of sync functions is necessary to prevent memory leak from context kept in
@@ -70,32 +78,107 @@ function useSyncSourceFromUrl(
     setUnappliedSourceArgs,
   ]);
 }
+
 function useSyncLayoutFromUrl(
   targetUrlState: AppURLState | undefined,
   { currentUserRequired }: { currentUserRequired: boolean },
 ) {
   const { setSelectedLayoutId } = useCurrentLayoutActions();
   const playerPresence = useMessagePipeline(selectPlayerPresence);
-  const [unappliedLayoutArgs, setUnappliedLayoutArgs] = useState(
-    targetUrlState ? { layoutId: targetUrlState.layoutId } : undefined,
+  const layoutManager = useLayoutManager();
+  const [unappliedLayoutArgs, setUnappliedLayoutArgs] = useState<
+    | {
+        layoutId?: LayoutID;
+        layoutUrl?: string;
+      }
+    | undefined
+  >(
+    targetUrlState
+      ? { layoutId: targetUrlState.layoutId, layoutUrl: targetUrlState.layoutUrl }
+      : undefined,
   );
+  const fetchingLayout = useRef(false);
+
+  const fetchLayout = useCallbackWithToast(
+    async (url: URL, name: string) => {
+      let res;
+      try {
+        res = await fetch(url.href);
+      } catch {
+        throw `Could not load the layout from ${url}`;
+      }
+      if (!res.ok) {
+        throw `Could not load the layout from ${url}`;
+      }
+      let data: LayoutData;
+      try {
+        data = await res.json();
+      } catch {
+        throw `${url} does not contain valid layout JSON`;
+      }
+
+      const layouts = await layoutManager.getLayouts();
+      const sourceLayout = layouts.find((layout) => layout.name === name);
+
+      let newLayout;
+      if (sourceLayout == undefined) {
+        newLayout = await layoutManager.saveNewLayout({
+          name,
+          data,
+          permission: "CREATOR_WRITE",
+        });
+      } else {
+        newLayout = await layoutManager.updateLayout({
+          id: sourceLayout.id,
+          name,
+          data,
+        });
+      }
+
+      setSelectedLayoutId(newLayout.id);
+      setUnappliedLayoutArgs((oldState) => ({ ...oldState, layoutUrl: undefined }));
+    },
+    [setSelectedLayoutId, layoutManager],
+  );
+
   // Select layout from URL.
   useEffect(() => {
-    if (!unappliedLayoutArgs?.layoutId) {
-      return;
+    if (unappliedLayoutArgs?.layoutId) {
+      // If our datasource requires a current user then wait until the player is
+      // available to load the layout since we may need to sync layouts first and
+      // that's only possible after the user has logged in.
+      if (currentUserRequired && playerPresence !== PlayerPresence.PRESENT) {
+        return;
+      }
+
+      log.debug(`Initializing layout from url: ${unappliedLayoutArgs.layoutId}`);
+      setSelectedLayoutId(unappliedLayoutArgs.layoutId);
+      setUnappliedLayoutArgs((oldState) => ({ ...oldState, layoutId: undefined }));
     }
 
-    // If our datasource requires a current user then wait until the player is
-    // available to load the layout since we may need to sync layouts first and
-    // that's only possible after the user has logged in.
-    if (currentUserRequired && playerPresence !== PlayerPresence.PRESENT) {
-      return;
-    }
+    if (unappliedLayoutArgs?.layoutUrl && !fetchingLayout.current) {
+      const url = new URL(unappliedLayoutArgs.layoutUrl);
+      const name = formatLayoutUrl(url);
+      log.debug(`Trying to load layout ${name} from ${url}`);
 
-    log.debug(`Initializing layout from url: ${unappliedLayoutArgs.layoutId}`);
-    setSelectedLayoutId(unappliedLayoutArgs.layoutId);
-    setUnappliedLayoutArgs({ layoutId: undefined });
-  }, [currentUserRequired, playerPresence, setSelectedLayoutId, unappliedLayoutArgs?.layoutId]);
+      fetchingLayout.current = true;
+      fetchLayout(url, name)
+        .catch(() => {
+          return;
+        })
+        .finally(() => {
+          fetchingLayout.current = false;
+        });
+    }
+  }, [
+    currentUserRequired,
+    playerPresence,
+    setSelectedLayoutId,
+    unappliedLayoutArgs?.layoutId,
+    unappliedLayoutArgs?.layoutUrl,
+    fetchLayout,
+    fetchingLayout,
+  ]);
 }
 
 function useSyncTimeFromUrl(targetUrlState: AppURLState | undefined) {

--- a/packages/studio-base/src/util/appURLState.test.ts
+++ b/packages/studio-base/src/util/appURLState.test.ts
@@ -49,6 +49,12 @@ describe("app state url parser", () => {
       });
     });
 
+    it("parses urls with only a layoutUrl", () => {
+      const url = urlBuilder();
+      url.searchParams.append("layoutUrl", "http://localhost/layout.json");
+      expect(parseAppURLState(url)?.layoutUrl).toBe("http://localhost/layout.json");
+    });
+
     it("parses data platform state urls", () => {
       const now: Time = { sec: new Date().getTime(), nsec: 0 };
       const time = toRFC3339String({ sec: now.sec + 500, nsec: 0 });
@@ -78,10 +84,11 @@ describe("app state url parser", () => {
 describe("app state encoding", () => {
   const baseURL = () => new URL("http://example.com");
 
-  it("encodes rosbag urls", () => {
+  it("encodes rosbag urls and layout urls", () => {
     expect(
       updateAppURLState(baseURL(), {
         layoutId: "123" as LayoutID,
+        layoutUrl: "http://localhost/layout.json",
         time: undefined,
         ds: "ros1-remote-bagfile",
         dsParams: {
@@ -89,7 +96,7 @@ describe("app state encoding", () => {
         },
       }).href,
     ).toEqual(
-      "http://example.com/?ds=ros1-remote-bagfile&ds.url=http%3A%2F%2Ffoxglove.dev%2Ftest.bag&layoutId=123",
+      "http://example.com/?ds=ros1-remote-bagfile&ds.url=http%3A%2F%2Ffoxglove.dev%2Ftest.bag&layoutId=123&layoutUrl=http%3A%2F%2Flocalhost%2Flayout.json",
     );
   });
 

--- a/packages/studio-base/src/util/appURLState.ts
+++ b/packages/studio-base/src/util/appURLState.ts
@@ -11,6 +11,7 @@ export type AppURLState = {
   ds?: string;
   dsParams?: Record<string, string>;
   layoutId?: LayoutID;
+  layoutUrl?: string;
   time?: Time;
 };
 
@@ -29,6 +30,14 @@ export function updateAppURLState(url: URL, urlState: AppURLState): URL {
       newURL.searchParams.set("layoutId", urlState.layoutId);
     } else {
       newURL.searchParams.delete("layoutId");
+    }
+  }
+
+  if ("layoutUrl" in urlState) {
+    if (urlState.layoutUrl) {
+      newURL.searchParams.set("layoutUrl", urlState.layoutUrl);
+    } else {
+      newURL.searchParams.delete("layoutUrl");
     }
   }
 
@@ -75,6 +84,7 @@ export function updateAppURLState(url: URL, urlState: AppURLState): URL {
 export function parseAppURLState(url: URL): AppURLState | undefined {
   const ds = url.searchParams.get("ds") ?? undefined;
   const layoutId = url.searchParams.get("layoutId");
+  const layoutUrl = url.searchParams.get("layoutUrl");
   const timeString = url.searchParams.get("time");
   const time = timeString == undefined ? undefined : fromRFC3339String(timeString);
   const dsParams: Record<string, string> = {};
@@ -88,6 +98,7 @@ export function parseAppURLState(url: URL): AppURLState | undefined {
   const state: AppURLState = omitBy(
     {
       layoutId: layoutId ? (layoutId as LayoutID) : undefined,
+      layoutUrl: layoutUrl ? layoutUrl : undefined,
       time,
       ds,
       dsParams: isEmpty(dsParams) ? undefined : dsParams,


### PR DESCRIPTION
**User-Facing Changes**
- Adds a `layoutUrl` parameter for deep links. e.g. `https://studio.foxglove.dev/?layoutUrl=%2Flayout.json`

**Description**
Loads the layout from the URL, saves it to storage, and opens the layout. Can be relative or absolute URL, as long as absolute URLs have correct CORS setup

Resolves [foxglove/community#192](https://github.com/foxglove/community/issues/192)