### PR TITLE
CBUF service calls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,42 +67,6 @@ jobs:
 
       - run: ${{ matrix.config.command }}
 
-  storybook:
-    name: storybook (ubuntu-20.04)
-    runs-on: ubuntu-20.04
-
-    steps:
-      - uses: actions/checkout@v4.1.0
-        with:
-          fetch-depth: 0 # Required for Chromatic
-          lfs: true
-
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16.17
-      - run: corepack enable yarn
-
-      - name: Restore cache
-        uses: actions/cache@v3.3.2
-        with:
-          path: |
-            .yarn/cache
-            **/node_modules
-          key: v5-${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: v5-${{ runner.os }}-yarn-
-
-      - run: yarn install --immutable
-
-      - run: yarn workspace @foxglove/studio-base run storybook:build
-
-      - uses: chromaui/action@v1
-        with:
-          autoAcceptChanges: main
-          exitOnceUploaded: true
-          onlyChanged: true
-          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          storybookBuildDir: storybook-static
-
   integration:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
@@ -152,7 +116,7 @@ jobs:
   release:
     name: Publish to S3 and GHCR
     runs-on: ubuntu-20.04
-    needs: [test, storybook, integration]
+    needs: [test, integration]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: read

--- a/packages/mcap-support/package.json
+++ b/packages/mcap-support/package.json
@@ -42,6 +42,6 @@
     "flatbuffers": "23.5.26",
     "flatbuffers_reflection": "0.0.7",
     "protobufjs": "patch:protobufjs@7.2.4#../../patches/protobufjs.patch",
-    "wasm-cbuf": "2.2.0"
+    "wasm-cbuf": "2.3.0"
   }
 }

--- a/packages/studio-base/package.json
+++ b/packages/studio-base/package.json
@@ -181,6 +181,7 @@
     "use-immer": "0.9.0",
     "use-sync-external-store": "1.2.0",
     "uuid": "9.0.1",
+    "wasm-cbuf": "2.3.0",
     "webpack": "5.88.2",
     "zustand": "4.4.1"
   }

--- a/packages/studio-base/src/players/FoxgloveWebSocketPlayer/CbufMessageWriter.ts
+++ b/packages/studio-base/src/players/FoxgloveWebSocketPlayer/CbufMessageWriter.ts
@@ -1,0 +1,46 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Cbuf, { CbufMessage, CbufMessageMap, CbufHashMap, CbufMessageDefinition } from "wasm-cbuf";
+
+import { MessageWriter } from "./MessageWriter";
+
+function nowSeconds(): number {
+  return Date.now() / 1000;
+}
+
+export class CbufMessageWriter implements MessageWriter {
+  #schemaMap: CbufMessageMap;
+  #hashMap: CbufHashMap;
+  #msgdef: CbufMessageDefinition;
+
+  public constructor(schemaText: string, messageType: string) {
+    const res = Cbuf.parseCBufSchema(schemaText);
+    if (res.error) {
+      throw new Error(`Error parsing cbuf schema: ${res.error}\n\n${schemaText}`);
+    }
+    this.#schemaMap = res.schema;
+    this.#hashMap = Cbuf.schemaMapToHashMap(this.#schemaMap);
+    const msgdef = this.#schemaMap.get(messageType);
+    if (!msgdef) {
+      throw new Error(`Message type ${messageType} not found in schema`);
+    }
+    this.#msgdef = msgdef;
+  }
+
+  public writeMessage(message: unknown): Uint8Array {
+    const msgEvent: CbufMessage = {
+      typeName: this.#msgdef.name ?? "",
+      size: 0,
+      variant: 0,
+      hashValue: this.#msgdef.hashValue,
+      timestamp: nowSeconds(),
+      message: message as Record<string, unknown>,
+    };
+    msgEvent.size = Cbuf.serializedMessageSize(this.#schemaMap, this.#hashMap, msgEvent);
+
+    const buffer = Cbuf.serializeMessage(this.#schemaMap, this.#hashMap, msgEvent);
+    return new Uint8Array(buffer);
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2865,6 +2865,7 @@ __metadata:
     use-immer: 0.9.0
     use-sync-external-store: 1.2.0
     uuid: 9.0.1
+    wasm-cbuf: 2.3.0
     webpack: 5.88.2
     zustand: 4.4.1
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -2507,7 +2507,7 @@ __metadata:
     flatbuffers_reflection: 0.0.7
     protobufjs: "patch:protobufjs@7.2.4#../../patches/protobufjs.patch"
     typescript: 5.2.2
-    wasm-cbuf: 2.2.0
+    wasm-cbuf: 2.3.0
   languageName: unknown
   linkType: soft
 
@@ -22040,12 +22040,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wasm-cbuf@npm:2.2.0":
-  version: 2.2.0
-  resolution: "wasm-cbuf@npm:2.2.0"
+"wasm-cbuf@npm:2.3.0":
+  version: 2.3.0
+  resolution: "wasm-cbuf@npm:2.3.0"
   dependencies:
     "@foxglove/message-definition": ^0.2.0
-  checksum: 501c3ffbf9b54a53bde5b190ec1387902348c88778a8a4a7d3ea8f1556bdbc9aae0a22b5792ab0dfb51d8d17d582108b1849d2a12ddb83caf036abbd6422f092
+  checksum: bf34d068c1ffa5c60a9165236590898125800918229df66997c41bcc8bd5944d55a1eadd0de94027e8ecad54b2d4c1aa6ea8cdc368e76d064d2f3de6f4c260a3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**User-Facing Changes**
- Call Service panel now works with servers that advertise `"cbuf"` encoded services

**Description**
There are a few places in the WebSocket protocol where encodings or type names are not explicitly specified and need to be inferred using assumptions from the ROS world. One is that the schema encoding can be assumed given the message encoding (json -> jsonschema, cdr -> ros2idl, etc) and the other is the service request and response type names are the service `"type"` suffixed with `_Request` and `_Response`.

A more thorough fix would involve breaking changes to ws-protocol to explicitly specifying schema encodings and request and response type names. This change continues the status quo but with special handling for cbuf, similar to how ROS is special-cased.