### PR TITLE
tabs names are no longer editable in kiosk mode

### DIFF
--- a/packages/studio-base/src/panels/Tab/ToolbarTab.tsx
+++ b/packages/studio-base/src/panels/Tab/ToolbarTab.tsx
@@ -18,12 +18,12 @@ import textMetrics from "text-metrics";
 import { makeStyles } from "tss-react/mui";
 
 import { PANEL_TOOLBAR_MIN_HEIGHT } from "@foxglove/studio-base/components/PanelToolbar";
-import { TabActions } from "@foxglove/studio-base/panels/Tab/TabDndContext";
-import { fontSansSerif } from "@foxglove/theme";
 import {
   useWorkspaceStore,
   WorkspaceStoreSelectors,
 } from "@foxglove/studio-base/context/Workspace/WorkspaceContext";
+import { TabActions } from "@foxglove/studio-base/panels/Tab/TabDndContext";
+import { fontSansSerif } from "@foxglove/theme";
 
 const MAX_TAB_WIDTH = 120;
 const MIN_ACTIVE_TAB_WIDTH = 40;
@@ -165,7 +165,7 @@ export function ToolbarTab(props: Props): JSX.Element {
         }
       });
     }
-  }, [isActive, selectTab, inputRef]);
+  }, [isActive, selectTab, kioskModeActive, inputRef]);
 
   const endTitleEditing = useCallback(() => {
     setEditingTitle(false);

--- a/packages/studio-base/src/panels/Tab/ToolbarTab.tsx
+++ b/packages/studio-base/src/panels/Tab/ToolbarTab.tsx
@@ -20,6 +20,10 @@ import { makeStyles } from "tss-react/mui";
 import { PANEL_TOOLBAR_MIN_HEIGHT } from "@foxglove/studio-base/components/PanelToolbar";
 import { TabActions } from "@foxglove/studio-base/panels/Tab/TabDndContext";
 import { fontSansSerif } from "@foxglove/theme";
+import {
+  useWorkspaceStore,
+  WorkspaceStoreSelectors,
+} from "@foxglove/studio-base/context/Workspace/WorkspaceContext";
 
 const MAX_TAB_WIDTH = 120;
 const MIN_ACTIVE_TAB_WIDTH = 40;
@@ -130,6 +134,7 @@ export function ToolbarTab(props: Props): JSX.Element {
   const onChangeTitleInput = useCallback((ev: React.ChangeEvent<HTMLInputElement>) => {
     setTitle(ev.target.value);
   }, []);
+  const kioskModeActive = useWorkspaceStore(WorkspaceStoreSelectors.selectKioskModeActive);
 
   const { selectTab, removeTab } = useMemo(
     () => ({
@@ -149,7 +154,7 @@ export function ToolbarTab(props: Props): JSX.Element {
   const onClickTab = useCallback(() => {
     if (!isActive) {
       selectTab();
-    } else {
+    } else if (!kioskModeActive) {
       setEditingTitle(true);
 
       setImmediate(() => {
@@ -215,6 +220,7 @@ export function ToolbarTab(props: Props): JSX.Element {
         [classes.hidden]: hidden,
       })}
       style={{
+        userSelect: "none",
         minWidth: isActive
           ? `calc(max(${MIN_ACTIVE_TAB_WIDTH}px,  min(${Math.ceil(
               measureText(tabTitle) + 30,


### PR DESCRIPTION
**User-Facing Changes**
- (improvement) Tab name text can no longer be selected.
- (fix) Tab name text is no longer editable if in kiosk mode.

**Description**

These changes improve user experience on touch screen. User can no longer accidentally select the tab text while changing tabs, and user can no longer edit text while in kiosk mode.