### PR TITLE
Fix GLTF model loading

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
   "debug.javascript.autoAttachFilter": "onlyWithFlag",
   "debug.toolBarLocation": "docked",
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,


### PR DESCRIPTION
**User-Facing Changes**
- GLTF (`.glb`) models can be loaded over a WebSocket connection

**Description**
- The GLTF model loading code in `ModelCache.ts` was calling `fetchAsset()` to retrieve binary data for a model by URL, and if the header matched the GLTF magic bytes, the three.js loader was used to fetch the asset again via URL and parse it. This worked for URLs the three.js loader could fetch such as http(s)://* but failed for special URLs such as `package://*` which Studio has special handling for, and could result in extracting data out of an MCAP, retrieving over WebSocket, etc. This fixes the loading code to only fetch GLTF assets once and parse it instead of load+parse.